### PR TITLE
Added copy to clipboard functionality and a few hotkeys.

### DIFF
--- a/src/CymaticLabs.InfluxDB.Studio/AppForm.Designer.cs
+++ b/src/CymaticLabs.InfluxDB.Studio/AppForm.Designer.cs
@@ -473,7 +473,7 @@
             this.runQueryButton.Name = "runQueryButton";
             this.runQueryButton.Size = new System.Drawing.Size(23, 22);
             this.runQueryButton.Text = "runQueryButton";
-            this.runQueryButton.ToolTipText = "Run Query";
+            this.runQueryButton.ToolTipText = "Run Query (F5)";
             this.runQueryButton.Click += new System.EventHandler(this.runQueryButton_Click);
             // 
             // toolStripSeparator2

--- a/src/CymaticLabs.InfluxDB.Studio/Controls/ExtendedTabControl.cs
+++ b/src/CymaticLabs.InfluxDB.Studio/Controls/ExtendedTabControl.cs
@@ -175,6 +175,21 @@ namespace CymaticLabs.InfluxDB.Studio.Controls
                 // Now show the context menu
                 tabContextMenuStrip.Show(this, e.Location);
             }
+            else if (e.Button == MouseButtons.Middle)
+            {
+                // Go through and get the tab that was middle-clicked
+                Point p = PointToClient(Cursor.Position);
+                for (int i = 0; i < TabCount; i++)
+                {
+                    r = GetTabRect(i);
+
+                    if (r.Contains(p))
+                    {
+                        CloseTab(TabPages[i]);
+                        break;
+                    }
+                }
+            }
         }
 
         // Handles click of tab context menu "Close"

--- a/src/CymaticLabs.InfluxDB.Studio/Controls/QueryControl.Designer.cs
+++ b/src/CymaticLabs.InfluxDB.Studio/Controls/QueryControl.Designer.cs
@@ -67,6 +67,7 @@
             this.queryEditor.Name = "queryEditor";
             this.queryEditor.Size = new System.Drawing.Size(916, 128);
             this.queryEditor.TabIndex = 0;
+            this.queryEditor.KeyUp += new System.Windows.Forms.KeyEventHandler(this.queryEditor_KeyUp);
             // 
             // panel1
             // 

--- a/src/CymaticLabs.InfluxDB.Studio/Controls/QueryControl.cs
+++ b/src/CymaticLabs.InfluxDB.Studio/Controls/QueryControl.cs
@@ -115,5 +115,19 @@ namespace CymaticLabs.InfluxDB.Studio.Controls
         }
 
         #endregion Methods
+
+        #region Event Handlers
+
+        private async void queryEditor_KeyUp(object sender, KeyEventArgs e)
+        {
+            switch (e.KeyCode)
+            {
+                case Keys.F5:
+                    await ExecuteRequestAsync();
+                    break;
+            }
+        }
+
+        #endregion Event Handlers
     }
 }

--- a/src/CymaticLabs.InfluxDB.Studio/Controls/QueryResultsControl.Designer.cs
+++ b/src/CymaticLabs.InfluxDB.Studio/Controls/QueryResultsControl.Designer.cs
@@ -61,6 +61,7 @@
             this.listView.TabIndex = 0;
             this.listView.UseCompatibleStateImageBehavior = false;
             this.listView.View = System.Windows.Forms.View.Details;
+            this.listView.KeyUp += new System.Windows.Forms.KeyEventHandler(this.listView_KeyUp);
             // 
             // contextMenuStrip
             // 

--- a/src/CymaticLabs.InfluxDB.Studio/Controls/QueryResultsControl.cs
+++ b/src/CymaticLabs.InfluxDB.Studio/Controls/QueryResultsControl.cs
@@ -303,5 +303,53 @@ namespace CymaticLabs.InfluxDB.Studio.Controls
         }
 
         #endregion Methods
+
+        private void listView_KeyUp(object sender, KeyEventArgs e)
+        {
+            if (sender != listView) return;
+
+            if (e.Control)
+            {
+                switch (e.KeyCode)
+                {
+                    case Keys.A:
+                        SelectedAll();
+                        break;
+                    case Keys.C:
+                        CopySelectedToClipboard();
+                        break;
+                }
+            }
+        }
+
+        private void SelectedAll()
+        {
+            foreach (ListViewItem li in listView.Items)
+            {
+                li.Selected = true;
+            }
+        }
+
+        private void CopySelectedToClipboard()
+        {
+            var sb = new StringBuilder();
+
+            foreach (ListViewItem li in listView.Items)
+            {
+                if (!li.Selected) continue;
+
+                // (skip first column which is just row # label)
+                for (var i = 1; i < li.SubItems.Count; i++)
+                {
+                    var sli = li.SubItems[i];
+                    sb.Append(sli.Text);
+                    if (i < li.SubItems.Count - 1) sb.Append('\t');
+                }
+
+                sb.Append(Environment.NewLine);
+            }
+
+            Clipboard.SetText(sb.ToString());
+        }
     }
 }


### PR DESCRIPTION
I was surprised that it isn't possible to copy query results into the clipboard, so I added such functionality + hotkeys.

**Tabs**
middle mouse click - close tab under the cursor
**QueryControl**
F5 - run the current query
**QueryResultsControl**
Ctrl+A - select all
Ctrl+C - copy to clipboard